### PR TITLE
Fix make program readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Local IDE files
+mtb_shared/
+PSoC62_App/.mtbqueryapi
+PSoC62_App/.settings/modustoolbox.prefs

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Compile in terminal as shown below (or use ModusToolbox IDE).
 Connect the PSoC62 pioneer kit to your computer and execute the command below.
 
    ```bash
-   make flash
+   make program
    ```
 
 ### Run


### PR DESCRIPTION
- Fixed `make program` command in README
- Added top-level `.gitignore` to ignore some files generated by IDE at build